### PR TITLE
#6: Fix element_validate_integer_positive and remove elements module

### DIFF
--- a/paragraphs.module
+++ b/paragraphs.module
@@ -561,10 +561,8 @@ function paragraphs_field_instance_settings_form($field, $instance) {
     '#required' => TRUE,
   );
 
-  $elements_exists = module_exists('elements');
   $element['default_edit_mode_override'] = array(
-    // If the Elements module is installed then use a real number field.
-    '#type' => $elements_exists ? 'numberfield' : 'textfield',
+    '#type' => 'number',
     '#title' => t('Edit mode override'),
     '#title_display' => 'invisible',
     '#field_prefix' => t('Force items to display as "Open" when there are less then '),
@@ -579,13 +577,10 @@ function paragraphs_field_instance_settings_form($field, $instance) {
     '#size' => 2,
     '#maxlength' => 2,
     // Specify width, since size property isn't supported on number fields.
-    '#attributes' => $elements_exists ? array('style' => 'width:3em') : array(),
+    '#attributes' => array('style' => 'width:3em'),
     '#min' => 1,
     '#max' => 99,
   );
-  if (!$elements_exists) {
-    $element['default_edit_mode_override']['#element_validate'] = array('element_validate_integer_positive');
-  }
 
   $element['add_mode'] = array(
     '#type' => 'select',


### PR DESCRIPTION
Per https://api.backdropcms.org/change-records/elementvalidateinteger-and-elementvalidateintegerpositive-replaced-number-element
and
https://www.drupal.org/node/1315186