### PR TITLE
Issue #117. Add property_type and property_callback to field definition

### DIFF
--- a/paragraphs.module
+++ b/paragraphs.module
@@ -498,6 +498,8 @@ function paragraphs_field_info() {
     'default_widget' => 'paragraphs_hidden',
     'default_formatter' => 'paragraphs_view',
     'settings' => array(),
+    'property_type' => 'paragraphs_item',
+    'property_callbacks' => array('paragraphs_entity_metadata_property_callback'),
   );
   return $info;
 }
@@ -1221,7 +1223,7 @@ function paragraphs_field_property_get($entity, array $options, $name, $entity_t
 function paragraphs_field_property_set($entity, $name, $value, $langcode, $entity_type) {
   $field = field_info_field($name);
   $columns = array_keys($field['columns']);
-  $langcode = entity_metadata_field_get_language($entity_type, $entity, $field, $langcode);
+  $langcode = entity_plus_metadata_field_get_language($entity_type, $entity, $field, $langcode);
   $values = $field['cardinality'] == 1 ? array($value) : (array) $value;
 
   $items = array();


### PR DESCRIPTION
Fixes #117

I found this issues when testing entity_token. It can't create tokens for Paragraphs fields unless these lines are there. They were removed when ported - yet the callback functions are all there!