### PR TITLE
Issue #62: organize buttons into a dropdown

### DIFF
--- a/css/paragraphs.css
+++ b/css/paragraphs.css
@@ -30,28 +30,55 @@ html.dialog-open {
   right: 0;
   display: block;
   z-index: 100;
-  background: #eee;
+  background: #fff;
   border-radius: 4px;
-  border: 0;
+  border: 1px solid #eee;
   margin-top: 5px;
 }
 .paragraphs-actions-more .details-child-wrapper:before {
   content: "";
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-bottom: 8px solid #eee;
-  height: 0;
-  right: 18px;
+  display: inline-block;
   position: absolute;
-  top: -8px;
-  width: 0;
+  left: auto;
+  right: 18px;
+  top: -16px;
+  border: 8px solid transparent;
+  border-bottom: 8px solid #eee;
 }
-.paragraphs-actions-more .details-child-wrapper input {
-  margin-left: 1em;
-  margin-right: 1em;
+.paragraphs-actions-more .details-child-wrapper:after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  left: auto;
+  right: 19px;
+  top: -14px;
+  border: 7px solid transparent;
+  border-bottom: 7px solid #fff;
+}
+.paragraphs-actions-more .details-child-wrapper input.form-submit {
+  padding: 0.5em 1em;
+  margin: 0;
+  border: 0;
+  border-radius: unset;
+  box-shadow: none;
+  /* background-color: transparent; */
+  line-height: normal;
+  transition: none;
+  text-align: left;
+  width: 100%;
+}
+.paragraphs-actions-more .details-child-wrapper input.form-submit:hover {
+  box-shadow: none;
+}
+.paragraphs-actions-more .details-child-wrapper input.form-submit:not(.button-danger):hover {
+  color: #ffffff;
+  background-color: #0074bd;
 }
 .paragraphs-actions-more .details-child-wrapper input:first-child {
-  margin-top: 1em;
+  margin-top: 0.5em;
+}
+.paragraphs-actions-more .details-child-wrapper input:last-child {
+  margin-bottom: 0.5em;
 }
 
 .field-widget-paragraphs-embed {

--- a/css/paragraphs.css
+++ b/css/paragraphs.css
@@ -20,7 +20,6 @@ html.dialog-open {
 .paragraphs-actions-more summary {
   border: 0;
   list-style: none;
-  transform: rotate(90deg);
 }
 .paragraphs-actions-more>summary::-webkit-details-marker {
   display: none;
@@ -32,7 +31,7 @@ html.dialog-open {
   z-index: 100;
   background: #fff;
   border-radius: 4px;
-  border: 1px solid #eee;
+  border: 2px solid #ccc;
   margin-top: 5px;
 }
 .paragraphs-actions-more .details-child-wrapper:before {
@@ -40,20 +39,20 @@ html.dialog-open {
   display: inline-block;
   position: absolute;
   left: auto;
-  right: 18px;
-  top: -16px;
-  border: 8px solid transparent;
-  border-bottom: 8px solid #eee;
+  right: 17px;
+  top: -18px;
+  border: 9px solid transparent;
+  border-bottom: 9px solid #ccc;
 }
 .paragraphs-actions-more .details-child-wrapper:after {
   content: "";
   display: inline-block;
   position: absolute;
   left: auto;
-  right: 19px;
+  right: 18px;
   top: -14px;
-  border: 7px solid transparent;
-  border-bottom: 7px solid #fff;
+  border: 8px solid transparent;
+  border-bottom: 8px solid #fff;
 }
 .paragraphs-actions-more .details-child-wrapper input.form-submit {
   padding: 0.5em 1em;
@@ -61,7 +60,6 @@ html.dialog-open {
   border: 0;
   border-radius: unset;
   box-shadow: none;
-  /* background-color: transparent; */
   line-height: normal;
   transition: none;
   text-align: left;

--- a/css/paragraphs.css
+++ b/css/paragraphs.css
@@ -2,23 +2,9 @@ html.dialog-open {
   position: inherit;
 }
 
-.field-widget-paragraphs-embed table td.paragraph-item {
-  display: grid;
-}
-
-.field-widget-paragraphs-embed table td.paragraph-item>div {
-  grid-column: 1 / 3;
-}
-
-.field-widget-paragraphs-embed table td.paragraph-item>.paragraph-bundle-title {
-  grid-column: 1;
-  grid-row: 1;
-}
-
-.field-widget-paragraphs-embed table td.paragraph-item>.inner-actions {
-  grid-column: 2;
-  grid-row: 1;
-  text-align: right;
+.field-widget-paragraphs-embed table td.paragraph-item .paragraph-bundle-header {
+  display: flex;
+  justify-content: space-between;
 }
 
 .field-widget-paragraphs-embed {

--- a/css/paragraphs.css
+++ b/css/paragraphs.css
@@ -33,6 +33,7 @@ html.dialog-open {
   border-radius: 4px;
   border: 2px solid #ccc;
   margin-top: 5px;
+  box-shadow: 0 0 4px #ddd;
 }
 .paragraphs-actions-more .details-child-wrapper:before {
   content: "";

--- a/css/paragraphs.css
+++ b/css/paragraphs.css
@@ -6,6 +6,51 @@ html.dialog-open {
   display: flex;
   justify-content: space-between;
 }
+.field-widget-paragraphs-embed table td.paragraph-item .inner-actions {
+  display: flex;
+}
+
+.paragraphs-actions-more {
+  position: relative;
+  border: 0;
+  margin: 0;
+  background-color: transparent;
+  overflow: visible;
+}
+.paragraphs-actions-more summary {
+  border: 0;
+  list-style: none;
+  transform: rotate(90deg);
+}
+.paragraphs-actions-more>summary::-webkit-details-marker {
+  display: none;
+}
+.paragraphs-actions-more .details-child-wrapper {
+  position: absolute;
+  left: 0;
+  display: block;
+  z-index: 100;
+  background: #eee;
+  border-radius: 4px;
+  border: 1px solid #eee;
+}
+.paragraphs-actions-more .details-child-wrapper:before {
+  content: "";
+  border: 8px solid transparent;
+  border-bottom: 12px solid #eee;
+  height: 0;
+  left: 10px;
+  position: absolute;
+  top: -20px;
+  width: 0;
+}
+.paragraphs-actions-more .details-child-wrapper input {
+  margin-left: 1em;
+  margin-right: 1em;
+}
+.paragraphs-actions-more .details-child-wrapper input:first-child {
+  margin-top: 1em;
+}
 
 .field-widget-paragraphs-embed {
   .removed {

--- a/css/paragraphs.css
+++ b/css/paragraphs.css
@@ -27,21 +27,23 @@ html.dialog-open {
 }
 .paragraphs-actions-more .details-child-wrapper {
   position: absolute;
-  left: 0;
+  right: 0;
   display: block;
   z-index: 100;
   background: #eee;
   border-radius: 4px;
-  border: 1px solid #eee;
+  border: 0;
+  margin-top: 5px;
 }
 .paragraphs-actions-more .details-child-wrapper:before {
   content: "";
-  border: 8px solid transparent;
-  border-bottom: 12px solid #eee;
+  border-left: 8px solid transparent;
+  border-right: 8px solid transparent;
+  border-bottom: 8px solid #eee;
   height: 0;
-  left: 10px;
+  right: 18px;
   position: absolute;
-  top: -20px;
+  top: -8px;
   width: 0;
 }
 .paragraphs-actions-more .details-child-wrapper input {

--- a/css/paragraphs.css
+++ b/css/paragraphs.css
@@ -2,6 +2,25 @@ html.dialog-open {
   position: inherit;
 }
 
+.field-widget-paragraphs-embed table td.paragraph-item {
+  display: grid;
+}
+
+.field-widget-paragraphs-embed table td.paragraph-item>div {
+  grid-column: 1 / 3;
+}
+
+.field-widget-paragraphs-embed table td.paragraph-item>.paragraph-bundle-title {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.field-widget-paragraphs-embed table td.paragraph-item>.inner-actions {
+  grid-column: 2;
+  grid-row: 1;
+  text-align: right;
+}
+
 .field-widget-paragraphs-embed {
   .removed {
     padding-left: 1.5rem;

--- a/css/paragraphs.css
+++ b/css/paragraphs.css
@@ -103,7 +103,8 @@ html.dialog-open {
   table {
     font-size: 0.923rem;
 
-    .paragraphs-item {
+    .paragraphs-item,
+    .form-item {
       white-space: normal;
     }
   }

--- a/js/paragraphs_actions.js
+++ b/js/paragraphs_actions.js
@@ -1,0 +1,46 @@
+/**
+ * @file
+ * Paragraphs actions JS code for paragraphs actions button.
+ */
+
+(function ($, Backdrop) {
+
+  'use strict';
+
+  /**
+   * Process paragraph_actions elements.
+   *
+   * @type {Backdrop~behavior}
+   *
+   * @prop {Backdrop~behaviorAttach} attach
+   *   Attaches paragraphsActions behaviors.
+   */
+  Backdrop.behaviors.paragraphsActions = {
+    attach: function (context, settings) {
+      var $actionsElement = $('.paragraphs-actions-more').once('paragraphs-actions-more', context);
+      // Attach event handlers to toggle button.
+      $actionsElement.each(function () {
+        var $this = $(this);
+
+        $this.on('focusout', function (e) {
+          setTimeout(function () {
+            if ($this.has(document.activeElement).length == 0) {
+              // The focus left the action button group, hide actions.
+              $this.removeAttr('open');
+            }
+          }, 1);
+        });
+      });
+      $(document).on('keydown.paragraphsActions', function (event) {
+        if (event.key === 'Escape') {
+          $('.paragraphs-actions-more').removeAttr('open');
+        }
+      });
+
+    },
+    detach: function (context) {
+      $(document).off('keydown.paragraphsActions');
+    }
+  };
+
+})(jQuery, Backdrop);

--- a/paragraphs.field_widget.inc
+++ b/paragraphs.field_widget.inc
@@ -491,20 +491,26 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
     $bundle_info = paragraphs_bundle_load($paragraphs_item->bundle);
 
     if ($bundle_info) {
-      $element['paragraph_bundle_title'] = array(
+      $element['paragraph_bundle_header'] = array(
+        '#type' => 'container',
+        '#weight' => -100,
+        '#attributes' => array(
+          'class' => array('paragraph-bundle-header'),
+        ),
+      );
+      $element['paragraph_bundle_header']['paragraph_bundle_title'] = array(
         '#type' => 'container',
         '#weight' => -100,
         '#attributes' => array(
           'class' => array('paragraph-bundle-title'),
         ),
       );
-      $element['paragraph_bundle_title']['info'] = array(
+      $element['paragraph_bundle_header']['paragraph_bundle_title']['info'] = array(
         '#markup' => t('@title type: %bundle', array('@title' => $instance_title, '%bundle' => $bundle_info->label)),
       );
     }
-    $element['inner_actions'] = array(
+    $element['paragraph_bundle_header']['inner_actions'] = array(
       '#type' => 'container',
-      '#weight' => -99,
       '#attributes' => array(
         'class' => array('inner-actions'),
       ),
@@ -516,7 +522,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
       if ($being_edited_paragraph) {
         if (!$is_new_paragraph && !entity_access('update', 'paragraphs_item', $paragraphs_item)) {
           foreach (element_children($element) as $key) {
-            if ($key != 'paragraph_bundle_title' && $key != 'inner_actions' && $key != 'paragraph_bundle_preview' && $key != 'access_info') {
+            if ($key != 'paragraph_bundle_header' && $key != 'inner_actions' && $key != 'paragraph_bundle_preview' && $key != 'access_info') {
               $element[$key]['#access'] = FALSE;
             }
           }
@@ -537,7 +543,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
         }
 
         if ($default_edit_mode != 'open') {
-          $element['inner_actions']['collapse_button'] = array(
+          $element['paragraph_bundle_header']['inner_actions']['collapse_button'] = array(
             '#delta' => $delta,
             '#name' => implode('_', $parents) . '_collapse_button',
             '#type' => 'submit',
@@ -572,7 +578,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
         }
 
         foreach (element_children($element) as $key) {
-          if ($key != 'paragraph_bundle_title' && $key != 'inner_actions' && $key != 'paragraph_bundle_preview' && $key != 'access_info') {
+          if ($key != 'paragraph_bundle_header' && $key != 'inner_actions' && $key != 'paragraph_bundle_preview' && $key != 'access_info') {
             $element[$key]['#access'] = FALSE;
           }
         }
@@ -592,7 +598,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           );
         }
 
-        $element['inner_actions']['edit_button'] = array(
+        $element['paragraph_bundle_header']['inner_actions']['edit_button'] = array(
           '#delta' => $delta,
           '#name' => implode('_', $parents) . '_edit_button',
           '#type' => 'submit',
@@ -622,7 +628,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
             $button_value = t('Publish');
             $unpublished_paragraph = TRUE;
           }
-          $element['inner_actions']['togglepublish_button'] = array(
+          $element['paragraph_bundle_header']['inner_actions']['togglepublish_button'] = array(
             '#delta' => $delta,
             '#name' => implode('_', $parents) . '_togglepublish_button',
             '#type' => 'submit',
@@ -644,7 +650,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
             ),
           );
         }
-        $element['inner_actions']['remove_button'] = array(
+        $element['paragraph_bundle_header']['inner_actions']['remove_button'] = array(
           '#delta' => $delta,
           '#name' => implode('_', $parents) . '_remove_button',
           '#type' => 'submit',
@@ -665,8 +671,8 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
         );
       }
 
-      if (isset($element['inner_actions']['edit_button']) && !$element['inner_actions']['edit_button']['#access']
-           && isset($element['inner_actions']['remove_button']) && !$element['inner_actions']['remove_button']['#access']) {
+      if (isset($element['paragraph_bundle_header']['inner_actions']['edit_button']) && !$element['paragraph_bundle_header']['inner_actions']['edit_button']['#access']
+           && isset($element['paragraph_bundle_header']['inner_actions']['remove_button']) && !$element['paragraph_bundle_header']['inner_actions']['remove_button']['#access']) {
         $element['access_info'] = array(
           '#type' => 'container',
           '#weight' => 9998,
@@ -676,7 +682,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           '#markup' => '<em>' . t('You are not allowed to edit or remove this @title item.', array('@title' => $instance_title)) . '</em>',
         );
       }
-      elseif (isset($element['inner_actions']['edit_button']) && !$element['inner_actions']['edit_button']['#access']) {
+      elseif (isset($element['paragraph_bundle_header']['inner_actions']['edit_button']) && !$element['paragraph_bundle_header']['inner_actions']['edit_button']['#access']) {
         $element['access_info'] = array(
           '#type' => 'container',
           '#weight' => 9998,
@@ -686,7 +692,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           '#markup' => '<em>' . t('You are not allowed to edit this @title item.', array('@title' => $instance_title)) . '</em>',
         );
       }
-      elseif (isset($element['inner_actions']['remove_button']) && !$element['inner_actions']['remove_button']['#access']) {
+      elseif (isset($element['paragraph_bundle_header']['inner_actions']['remove_button']) && !$element['paragraph_bundle_header']['inner_actions']['remove_button']['#access']) {
         $element['access_info'] = array(
           '#type' => 'container',
           '#weight' => 9998,
@@ -711,10 +717,10 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
         '%restore' => t('Restore'),
         ));
       $remove_button .= '</div>';
-      $element['inner_actions']['remove_button'] = array(
+      $element['paragraph_bundle_header']['inner_actions']['remove_button'] = array(
         '#markup' => $remove_button,
       );
-      $element['inner_actions']['restore_button'] = array(
+      $element['paragraph_bundle_header']['inner_actions']['restore_button'] = array(
         '#delta' => $delta,
         '#name' => implode('_', $parents) . '_restore_button',
         '#type' => 'submit',
@@ -732,7 +738,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           'class' => array('paragraphs-restore-button'),
         ),
       );
-      $element['inner_actions']['confirm_delete_button'] = array(
+      $element['paragraph_bundle_header']['inner_actions']['confirm_delete_button'] = array(
         '#delta' => $delta,
         '#name' => implode('_', $parents) . '_deleteconfirm_button',
         '#type' => 'submit',
@@ -767,7 +773,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
     $class = 'unpublished';
   }
   if (!empty($class)) {
-    $element['paragraph_bundle_title']['#attributes']['class'][] = $class;
+    $element['paragraph_bundle_header']['#attributes']['class'][] = $class;
   }
   $recursion--;
   return $element;
@@ -781,7 +787,7 @@ function _paragraphs_ajax_update_callback($form, $form_state) {
   $button = $form_state['triggering_element'];
 
   // Go three levels up in the form, to the whole widget.
-  $element = backdrop_array_get_nested_value($form, array_slice($button['#array_parents'], 0, -3));
+  $element = backdrop_array_get_nested_value($form, array_slice($button['#array_parents'], 0, -4));
 
   // Send back the rendered element and let Backdrop wrap it in an AJAX command.
   return backdrop_render($element);
@@ -1051,7 +1057,7 @@ function paragraphs_remove_submit(array $form, array &$form_state) {
   $delta = $button['#delta'];
 
   // Where in the form we'll find the parent element.
-  $address = array_slice($button['#array_parents'], 0, -3);
+  $address = array_slice($button['#array_parents'], 0, -4);
 
   // Go one level up in the form, to the widgets container.
   $parent_element = backdrop_array_get_nested_value($form, $address);
@@ -1115,7 +1121,7 @@ function paragraphs_togglepublish_submit(array $form, array &$form_state) {
   $delta = $button['#delta'];
 
   // Where in the form we'll find the parent element.
-  $address = array_slice($button['#array_parents'], 0, -3);
+  $address = array_slice($button['#array_parents'], 0, -4);
 
   // Go one level up in the form, to the widgets container.
   $parent_element = backdrop_array_get_nested_value($form, $address);
@@ -1178,7 +1184,7 @@ function paragraphs_edit_submit(array $form, array &$form_state) {
   $delta = $button['#delta'];
 
   // Where in the form we'll find the parent element.
-  $address = array_slice($button['#array_parents'], 0, -3);
+  $address = array_slice($button['#array_parents'], 0, -4);
 
   // Go one level up in the form, to the widgets container.
   $parent_element = backdrop_array_get_nested_value($form, $address);
@@ -1241,7 +1247,7 @@ function paragraphs_collapse_submit(array $form, array &$form_state) {
   $delta = $button['#delta'];
 
   // Where in the form we'll find the parent element.
-  $address = array_slice($button['#array_parents'], 0, -3);
+  $address = array_slice($button['#array_parents'], 0, -4);
 
   // Go one level up in the form, to the widgets container.
   $parent_element = backdrop_array_get_nested_value($form, $address);
@@ -1305,7 +1311,7 @@ function paragraphs_deleteconfirm_submit(array $form, array &$form_state) {
   $delta = $button['#delta'];
 
   // Where in the form we'll find the parent element.
-  $address = array_slice($button['#array_parents'], 0, -3);
+  $address = array_slice($button['#array_parents'], 0, -4);
 
   // Go one level up in the form, to the widgets container.
   $parent_element = backdrop_array_get_nested_value($form, $address);
@@ -1362,7 +1368,7 @@ function paragraphs_restore_submit(array $form, array &$form_state) {
   $delta = $button['#delta'];
 
   // Where in the form we'll find the parent element.
-  $address = array_slice($button['#array_parents'], 0, -3);
+  $address = array_slice($button['#array_parents'], 0, -4);
 
   // Go one level up in the form, to the widgets container.
   $parent_element = backdrop_array_get_nested_value($form, $address);

--- a/paragraphs.field_widget.inc
+++ b/paragraphs.field_widget.inc
@@ -155,16 +155,10 @@ function paragraphs_field_multiple_value_form($field, $instance, $langcode, $ite
 
   if (module_exists('file')) {
     // file.js triggers uploads when the main Submit button is clicked.
-    $field_elements['#attached']['js'] = array(
-      backdrop_get_path('module', 'file') . '/js/file.js',
-      array(
-        'data' => backdrop_get_path('module', 'paragraphs') . '/paragraphs.js',
-        'type' => 'file',
-        'weight' => 9999,
-      ),
-    );
+    $field_elements['#attached']['js'][] = backdrop_get_path('module', 'file') . '/js/file.js';
     $form_state['has_file_element'] = TRUE;
   }
+  $field_elements['#attached']['js'][] = backdrop_get_path('module', 'paragraphs') . '/paragraphs.js';
 
   return $field_elements;
 }
@@ -500,7 +494,6 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
       );
       $element['paragraph_bundle_header']['paragraph_bundle_title'] = array(
         '#type' => 'container',
-        '#weight' => -100,
         '#attributes' => array(
           'class' => array('paragraph-bundle-title'),
         ),
@@ -515,6 +508,16 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
         'class' => array('inner-actions'),
       ),
     );
+    $element['paragraph_bundle_header']['inner_actions']['more'] = array(
+    '#type' => 'details',
+    '#summary' => '...',
+    'child' => array(),
+    '#attributes' => array(
+      'class' => array('paragraphs-actions-more'),
+      'aria-label' => t('More actions'),
+    ),
+    '#weight' => 1003,
+  );
 
     if (!$deleted_paragraph) {
 
@@ -594,7 +597,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           $markup .= '</div>';
           $element['must_be_saved'] = array(
             '#markup' => $markup,
-            '#weight' => 998,
+            '#weight' => 1000,
           );
         }
 
@@ -628,7 +631,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
             $button_value = t('Publish');
             $unpublished_paragraph = TRUE;
           }
-          $element['paragraph_bundle_header']['inner_actions']['togglepublish_button'] = array(
+          $element['paragraph_bundle_header']['inner_actions']['more']['child']['togglepublish_button'] = array(
             '#delta' => $delta,
             '#name' => implode('_', $parents) . '_togglepublish_button',
             '#type' => 'submit',
@@ -639,18 +642,18 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
             ),
             '#limit_validation_errors' => array($parents),
             '#ajax' => array(
-              'callback' => '_paragraphs_ajax_update_callback',
+              'callback' => '_paragraphs_ajax_update_more_callback',
               'effect' => 'fade',
               'wrapper' => $element['#wrapper_id'],
             ),
             '#access' => entity_access('update', 'paragraphs_item', $paragraphs_item),
-            '#weight' => 1000,
+            '#weight' => 999,
             '#attributes' => array(
               'class' => array('paragraphs-togglepublish-button'),
             ),
           );
         }
-        $element['paragraph_bundle_header']['inner_actions']['remove_button'] = array(
+        $element['paragraph_bundle_header']['inner_actions']['more']['child']['remove_button'] = array(
           '#delta' => $delta,
           '#name' => implode('_', $parents) . '_remove_button',
           '#type' => 'submit',
@@ -659,12 +662,12 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           '#submit' => array('paragraphs_remove_submit'),
           '#limit_validation_errors' => array(),
           '#ajax' => array(
-            'callback' => '_paragraphs_ajax_update_callback',
+            'callback' => '_paragraphs_ajax_update_more_callback',
             'effect' => 'fade',
             'wrapper' => $element['#wrapper_id'],
           ),
           '#access' => entity_access('delete', 'paragraphs_item', $paragraphs_item),
-          '#weight' => 1001,
+          '#weight' => 999,
           '#attributes' => array(
             'class' => array('button-danger', 'paragraph-remove-button'),
           ),
@@ -672,7 +675,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
       }
 
       if (isset($element['paragraph_bundle_header']['inner_actions']['edit_button']) && !$element['paragraph_bundle_header']['inner_actions']['edit_button']['#access']
-           && isset($element['paragraph_bundle_header']['inner_actions']['remove_button']) && !$element['paragraph_bundle_header']['inner_actions']['remove_button']['#access']) {
+           && isset($element['paragraph_bundle_header']['inner_actions']['more']['child']['remove_button']) && !$element['paragraph_bundle_header']['inner_actions']['more']['child']['remove_button']['#access']) {
         $element['access_info'] = array(
           '#type' => 'container',
           '#weight' => 9998,
@@ -692,7 +695,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           '#markup' => '<em>' . t('You are not allowed to edit this @title item.', array('@title' => $instance_title)) . '</em>',
         );
       }
-      elseif (isset($element['paragraph_bundle_header']['inner_actions']['remove_button']) && !$element['paragraph_bundle_header']['inner_actions']['remove_button']['#access']) {
+      elseif (isset($element['paragraph_bundle_header']['inner_actions']['more']['child']['remove_button']) && !$element['paragraph_bundle_header']['inner_actions']['more']['child']['remove_button']['#access']) {
         $element['access_info'] = array(
           '#type' => 'container',
           '#weight' => 9998,
@@ -704,21 +707,25 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
       }
     }
     else {
-      $remove_button = '<p>' . t('This @title has been removed.', array('@title' => $instance_title)) . ' </p>';
-      $remove_button .= '<div class="messages warning">';
+      $remove_markup = '<p>' . t('This @title has been removed.', array('@title' => $instance_title)) . ' </p>';
+      $remove_markup .= '<div class="messages warning">';
       if (config_get('system.core', 'messages_dismissible')) {
         // Add the 'Dismiss' library and place a 'Dismiss' link on messages.
         backdrop_add_library('system', 'backdrop.dismiss');
-        $remove_button .= '<a href="#" class="dismiss" title="' . t('Dismiss') . '"><span class="element-invisible">' . t('Dismiss') . '</span></a>' . "\n";
+        $remove_markup .= '<a href="#" class="dismiss" title="' . t('Dismiss') . '"><span class="element-invisible">' . t('Dismiss') . '</span></a>' . "\n";
       }
-      $remove_button .= t('This @title will be permanently deleted when you press %confirm or save this page. (You can restore it with the %restore button or by closing this screen without saving.)', array(
+      $remove_markup .= t('This @title will be permanently deleted when you press %confirm or save this page. (You can restore it with the %restore button or by closing this screen without saving.)', array(
         '@title' => $instance_title,
         '%confirm' => t('Confirm Deletion'),
         '%restore' => t('Restore'),
         ));
-      $remove_button .= '</div>';
-      $element['paragraph_bundle_header']['inner_actions']['remove_button'] = array(
-        '#markup' => $remove_button,
+      $remove_markup .= '</div>';
+      $element['paragraph_bundle_header']['inner_actions']['more']['child']['remove_button'] = array(
+        '#markup' => '',
+      );
+      $element['remove_warning'] = array(
+        '#markup' => $remove_markup,
+        '#weight' => 1000,
       );
       $element['paragraph_bundle_header']['inner_actions']['restore_button'] = array(
         '#delta' => $delta,
@@ -786,8 +793,22 @@ function _paragraphs_ajax_update_callback($form, $form_state) {
   // Get the information on what we're updating.
   $button = $form_state['triggering_element'];
 
-  // Go three levels up in the form, to the whole widget.
+  // Go four levels up in the form, to the whole widget.
   $element = backdrop_array_get_nested_value($form, array_slice($button['#array_parents'], 0, -4));
+
+  // Send back the rendered element and let Backdrop wrap it in an AJAX command.
+  return backdrop_render($element);
+}
+
+/**
+ * FAPI #ajax callback to update a paragraphs item from the extra buttons.
+ */
+function _paragraphs_ajax_update_more_callback($form, $form_state) {
+  // Get the information on what we're updating.
+  $button = $form_state['triggering_element'];
+
+  // Go six levels up in the form, to the whole widget.
+  $element = backdrop_array_get_nested_value($form, array_slice($button['#array_parents'], 0, -6));
 
   // Send back the rendered element and let Backdrop wrap it in an AJAX command.
   return backdrop_render($element);
@@ -1057,7 +1078,7 @@ function paragraphs_remove_submit(array $form, array &$form_state) {
   $delta = $button['#delta'];
 
   // Where in the form we'll find the parent element.
-  $address = array_slice($button['#array_parents'], 0, -4);
+  $address = array_slice($button['#array_parents'], 0, -6);
 
   // Go one level up in the form, to the widgets container.
   $parent_element = backdrop_array_get_nested_value($form, $address);
@@ -1121,7 +1142,7 @@ function paragraphs_togglepublish_submit(array $form, array &$form_state) {
   $delta = $button['#delta'];
 
   // Where in the form we'll find the parent element.
-  $address = array_slice($button['#array_parents'], 0, -4);
+  $address = array_slice($button['#array_parents'], 0, -6);
 
   // Go one level up in the form, to the widgets container.
   $parent_element = backdrop_array_get_nested_value($form, $address);

--- a/paragraphs.field_widget.inc
+++ b/paragraphs.field_widget.inc
@@ -156,9 +156,9 @@ function paragraphs_field_multiple_value_form($field, $instance, $langcode, $ite
   if (module_exists('file')) {
     // file.js triggers uploads when the main Submit button is clicked.
     $field_elements['#attached']['js'][] = backdrop_get_path('module', 'file') . '/js/file.js';
+    $field_elements['#attached']['js'][] = backdrop_get_path('module', 'paragraphs') . '/paragraphs.js';
     $form_state['has_file_element'] = TRUE;
   }
-  $field_elements['#attached']['js'][] = backdrop_get_path('module', 'paragraphs') . '/paragraphs.js';
 
   return $field_elements;
 }
@@ -336,6 +336,7 @@ function _paragraphs_add_more_buttons($instance, $langcode, $form_state, $field_
           );
         }
       }
+      $field_elements['#attached']['js'][] = backdrop_get_path('module', 'paragraphs') . '/js/paragraphs_actions.js';
     }
     else {
       $field_elements['add_more']['add_more'] = array(

--- a/paragraphs.field_widget.inc
+++ b/paragraphs.field_widget.inc
@@ -159,6 +159,7 @@ function paragraphs_field_multiple_value_form($field, $instance, $langcode, $ite
     $field_elements['#attached']['js'][] = backdrop_get_path('module', 'paragraphs') . '/paragraphs.js';
     $form_state['has_file_element'] = TRUE;
   }
+  $field_elements['#attached']['js'][] = backdrop_get_path('module', 'paragraphs') . '/js/paragraphs_actions.js';
 
   return $field_elements;
 }
@@ -240,7 +241,7 @@ function _paragraphs_add_more_buttons($instance, $langcode, $form_state, $field_
       );
     }
     elseif (count($select_bundles)) {
-      // uasort($select_bundles, 'backdrop_sort_weight');
+      // uasort($select_bundles, 'backdrop_sort_weight');.
       backdrop_sort($select_bundles, array('weight' => SORT_NUMERIC));
 
       if ($field['cardinality'] == FIELD_CARDINALITY_UNLIMITED || $field_state['real_items_count'] < $field['cardinality']) {
@@ -281,7 +282,7 @@ function _paragraphs_add_more_buttons($instance, $langcode, $form_state, $field_
           }
         }
         else {
-          // uasort($select_bundles, 'backdrop_sort_weight');
+          // uasort($select_bundles, 'backdrop_sort_weight');.
           backdrop_sort($select_bundles, array('weight' => SORT_NUMERIC));
 
           $select_list = array();
@@ -336,7 +337,6 @@ function _paragraphs_add_more_buttons($instance, $langcode, $form_state, $field_
           );
         }
       }
-      $field_elements['#attached']['js'][] = backdrop_get_path('module', 'paragraphs') . '/js/paragraphs_actions.js';
     }
     else {
       $field_elements['add_more']['add_more'] = array(
@@ -719,7 +719,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
         '@title' => $instance_title,
         '%confirm' => t('Confirm Deletion'),
         '%restore' => t('Restore'),
-        ));
+      ));
       $remove_markup .= '</div>';
       $element['paragraph_bundle_header']['inner_actions']['more']['child']['remove_button'] = array(
         '#markup' => '',

--- a/paragraphs.field_widget.inc
+++ b/paragraphs.field_widget.inc
@@ -273,7 +273,9 @@ function _paragraphs_add_more_buttons($instance, $langcode, $form_state, $field_
               '#name' => strtr($id_prefix, '-', '_') . '_add_more_add_more_bundle_' . $machine_name,
               '#value' => t('Add !title', array('!title' => $bundle['name'])),
               '#access' => entity_access('create', 'paragraphs_item', $entity_shell),
-              '#attributes' => array('class' => array('field-add-more-submit', 'paragraphs-add-more-submit')),
+              '#attributes' => array(
+                'class' => array('field-add-more-submit', 'paragraphs-add-more-submit'),
+              ),
               '#limit_validation_errors' => array(),
               '#submit' => array('paragraphs_add_more_submit'),
               '#ajax' => array(
@@ -298,7 +300,9 @@ function _paragraphs_add_more_buttons($instance, $langcode, $form_state, $field_
             '#name' => strtr($id_prefix, '-', '_') . '_add_more_type',
             '#title' => t('!title type', array('!title' => $instance_title)),
             '#options' => $select_list,
-            '#attributes' => array('class' => array('field-add-more-type')),
+            '#attributes' => array(
+              'class' => array('field-add-more-type'),
+            ),
             '#limit_validation_errors' => array(
               array_merge($parents, array($field_name, $langcode)),
             ),
@@ -325,7 +329,9 @@ function _paragraphs_add_more_buttons($instance, $langcode, $form_state, $field_
             '#type' => 'submit',
             '#name' => strtr($id_prefix, '-', '_') . '_add_more_add_more',
             '#value' => $text,
-            '#attributes' => array('class' => array('field-add-more-submit', 'paragraphs-add-more-submit')),
+            '#attributes' => array(
+              'class' => array('field-add-more-submit', 'paragraphs-add-more-submit'),
+            ),
             '#limit_validation_errors' => array(),
             '#submit' => array('paragraphs_add_more_submit'),
             '#ajax' => array(
@@ -488,6 +494,9 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
       $element['paragraph_bundle_title'] = array(
         '#type' => 'container',
         '#weight' => -100,
+        '#attributes' => array(
+          'class' => array('paragraph-bundle-title'),
+        ),
       );
       $element['paragraph_bundle_title']['info'] = array(
         '#markup' => t('@title type: %bundle', array('@title' => $instance_title, '%bundle' => $bundle_info->label)),
@@ -495,7 +504,10 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
     }
     $element['inner_actions'] = array(
       '#type' => 'container',
-      '#weight' => 9999,
+      '#weight' => -99,
+      '#attributes' => array(
+        'class' => array('inner-actions'),
+      ),
     );
 
     if (!$deleted_paragraph) {
@@ -540,13 +552,20 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
             ),
             '#access' => entity_access('update', 'paragraphs_item', $paragraphs_item),
             '#weight' => 999,
+            '#attributes' => array(
+              'class' => array('paragraphs-collapse-button'),
+            ),
           );
+
         }
       }
       else {
         if ($default_edit_mode === 'preview' && entity_access('view', 'paragraphs_item', $paragraphs_item)) {
           $element['paragraph_bundle_preview'] = array(
             '#type' => 'container',
+            '#attributes' => array(
+              'class' => array('paragraph-bundle-preview'),
+            ),
           );
           $preview = $paragraphs_item->view('paragraphs_editor_preview', $langcode);
           $element['paragraph_bundle_preview']['preview'] = $preview;
@@ -567,7 +586,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           }
           $markup .= t('This content must be saved to record recent changes.');
           $markup .= '</div>';
-          $element['inner_actions']['must_be_saved'] = array(
+          $element['must_be_saved'] = array(
             '#markup' => $markup,
             '#weight' => 998,
           );
@@ -588,6 +607,9 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           ),
           '#access' => entity_access('update', 'paragraphs_item', $paragraphs_item),
           '#weight' => 999,
+          '#attributes' => array(
+            'class' => array('paragraphs-edit-button'),
+          ),
         );
       }
 
@@ -617,6 +639,9 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
             ),
             '#access' => entity_access('update', 'paragraphs_item', $paragraphs_item),
             '#weight' => 1000,
+            '#attributes' => array(
+              'class' => array('paragraphs-togglepublish-button'),
+            ),
           );
         }
         $element['inner_actions']['remove_button'] = array(
@@ -635,7 +660,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           '#access' => entity_access('delete', 'paragraphs_item', $paragraphs_item),
           '#weight' => 1001,
           '#attributes' => array(
-            'class' => array('button-danger'),
+            'class' => array('button-danger', 'paragraph-remove-button'),
           ),
         );
       }
@@ -703,6 +728,9 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
           'wrapper' => $element['#wrapper_id'],
         ),
         '#weight' => 1000,
+        '#attributes' => array(
+          'class' => array('paragraphs-restore-button'),
+        ),
       );
       $element['inner_actions']['confirm_delete_button'] = array(
         '#delta' => $delta,
@@ -719,7 +747,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
         ),
         '#weight' => 1001,
         '#attributes' => array(
-          'class' => array('button-danger'),
+          'class' => array('button-danger', 'paragraphs-deleteconfirm-button'),
         ),
       );
     }
@@ -739,11 +767,7 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
     $class = 'unpublished';
   }
   if (!empty($class)) {
-    $element['paragraph_bundle_title']['#attributes'] = array(
-      'class' => array(
-        $class,
-      ),
-    );
+    $element['paragraph_bundle_title']['#attributes']['class'][] = $class;
   }
   $recursion--;
   return $element;

--- a/paragraphs.field_widget.inc
+++ b/paragraphs.field_widget.inc
@@ -509,15 +509,15 @@ function paragraphs_field_widget_form_build(array &$form, array &$form_state, ar
       ),
     );
     $element['paragraph_bundle_header']['inner_actions']['more'] = array(
-    '#type' => 'details',
-    '#summary' => '...',
-    'child' => array(),
-    '#attributes' => array(
-      'class' => array('paragraphs-actions-more'),
-      'aria-label' => t('More actions'),
-    ),
-    '#weight' => 1003,
-  );
+      '#type' => 'details',
+      '#summary' => '...',
+      'child' => array(),
+      '#attributes' => array(
+        'class' => array('paragraphs-actions-more'),
+        'aria-label' => t('More actions'),
+      ),
+      '#weight' => 1003,
+    );
 
     if (!$deleted_paragraph) {
 

--- a/paragraphs.js
+++ b/paragraphs.js
@@ -22,4 +22,32 @@
     }
   };
 
+  /**
+   * Close any open "more actions" menus.
+   */
+  Backdrop.behaviors.closeMoreActions = {
+    attach: function (context) {
+      $('body', context).on('click', Backdrop.paragraphs.closeActionMenu);
+    },
+    detach: function (context) {
+      $('body', context).on('click', Backdrop.paragraphs.closeActionMenu);
+    }
+  };
+
+  Backdrop.paragraphs = Backdrop.paragraphs || {
+
+    /**
+     * Close any open actions menus if the click is outside of the menu.
+     */
+    closeActionMenu: function (event) {
+      var $moreactions = $('.paragraphs-actions-more');
+      var $body = $('body');
+      var insideMoreActions = $.contains(event.target, $body);
+      if (!insideMoreActions) {
+        $moreactions.removeAttr('open');
+      }
+    }
+
+  };
+
 })(jQuery);

--- a/paragraphs.js
+++ b/paragraphs.js
@@ -22,32 +22,4 @@
     }
   };
 
-  /**
-   * Close any open "more actions" menus.
-   */
-  Backdrop.behaviors.closeMoreActions = {
-    attach: function (context) {
-      $('body', context).on('click', Backdrop.paragraphs.closeActionMenu);
-    },
-    detach: function (context) {
-      $('body', context).on('click', Backdrop.paragraphs.closeActionMenu);
-    }
-  };
-
-  Backdrop.paragraphs = Backdrop.paragraphs || {
-
-    /**
-     * Close any open actions menus if the click is outside of the menu.
-     */
-    closeActionMenu: function (event) {
-      var $moreactions = $('.paragraphs-actions-more');
-      var $body = $('body');
-      var insideMoreActions = $.contains(event.target, $body);
-      if (!insideMoreActions) {
-        $moreactions.removeAttr('open');
-      }
-    }
-
-  };
-
 })(jQuery);

--- a/paragraphs.module
+++ b/paragraphs.module
@@ -912,6 +912,8 @@ function paragraphs_field_update($entity_type, $entity, $field, $instance, $lang
         $item->deleteRevision(TRUE);
       }
     }
+    list($entity_id,,) = entity_extract_ids($entity_type, $entity);
+    entity_get_controller($entity_type)->resetCache(array($entity_id));
   }
 }
 

--- a/paragraphs.module
+++ b/paragraphs.module
@@ -1355,7 +1355,10 @@ function theme_paragraphs_field_multiple_value_form(array $variables) {
           'data' => '',
           'class' => array('field-multiple-drag'),
         ),
-        backdrop_render($item),
+        array(
+          'data' => backdrop_render($item),
+          'class' => array('paragraph-item'),
+        ),
         array(
           'data' => $delta_element,
           'class' => array('delta-order'),


### PR DESCRIPTION
Fixes #62.

Alternative that puts buttons other than "Edit" into a dropdown. The dropdown is custom since there's nothing in core to help with dropdowns that contain buttons.