### PR TITLE
Issue #198: Prevent warnings if the allow_unpublish property doesn't exist.

### DIFF
--- a/paragraphs.install
+++ b/paragraphs.install
@@ -204,6 +204,9 @@ function paragraphs_update_1001() {
     $bundles[$bundle_object->bundle] = $bundle_object;
   }
   foreach ($bundles as $bundle) {
+    if (!property_exists($bundle, 'allow_unpublish')) {
+      $bundle->allow_unpublish = 0;
+    }
     paragraphs_bundle_save($bundle);
   }
   db_drop_table('paragraphs_bundle');


### PR DESCRIPTION
Fixes #198.